### PR TITLE
don't ignore itself

### DIFF
--- a/out/.gitignore
+++ b/out/.gitignore
@@ -1,1 +1,2 @@
 *
+!.gitignore


### PR DESCRIPTION
fix #7 

out/.gitignoreの自身の記述によって、自分もignoreされていたため、このテンプレートレポジトリから新たなレポジトリを作成した際に、out/.gitignoreがコピーされていなかったものを修正。