### PR TITLE
workflows/create-issue: マージコミットでエラーにならないようにする

### DIFF
--- a/.github/workflows/create-issue.yaml
+++ b/.github/workflows/create-issue.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Get all parents
         # https://git-scm.com/docs/git-rev-parse#_other_rev_parent_shorthand_notations
         run: echo "HAS_PARENT=$(git rev-parse HEAD^@ | wc -l)" >> $GITHUB_ENV


### PR DESCRIPTION
git rev-parse HEAD^@はマージコミットでは複数行を出力するので，GITHUB_ENVのフォーマットが壊れてしまう 代わりに出力の行数を数えることにする