### PR TITLE
コードブロックがはみ出さないようにする。

### DIFF
--- a/bushi.tex
+++ b/bushi.tex
@@ -61,6 +61,8 @@ KMCでは、新入生プロジェクト以外にも様々なプロジェクト�
 %\include*{recent-kmc/heavylove}
 
 \part{部員のコラム}
+\include{test}
+
 \include{atogaki}
 
 %\include{kousei}

--- a/kiji/test.md
+++ b/kiji/test.md
@@ -1,0 +1,10 @@
+# てすと
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
+  <Link rel="lrdd" template="https://pawoo.net/.well-known/webfinger?resource={uri}"/>
+</XRD>
+```
+
+これがはみ出さないでほしい。

--- a/luakmcbook.dtx
+++ b/luakmcbook.dtx
@@ -50,7 +50,6 @@
 \newcommand{\ImportTok}[1]{#1}
 \newcommand{\InformationTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{#1}}}}
 \newcommand{\KeywordTok}[1]{\textcolor[rgb]{0.00,0.44,0.13}{\textbf{#1}}}
-\newcommand{\NormalTok}[1]{#1}
 \newcommand{\OperatorTok}[1]{\textcolor[rgb]{0.40,0.40,0.40}{#1}}
 \newcommand{\OtherTok}[1]{\textcolor[rgb]{0.00,0.44,0.13}{#1}}
 \newcommand{\PreprocessorTok}[1]{\textcolor[rgb]{0.74,0.48,0.00}{#1}}
@@ -65,7 +64,7 @@
 
 \usepackage{fvextra}
 \DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\}, breaklines, breaknonspaceingroup, breakanywhere}
-\let\NormalTok\texttt
+\newcommand{\NormalTok}[1]{\texttt{#1}}
 
 % === ここまで Pandoc のテンプレからもってきたやつ
 

--- a/luakmcbook.dtx
+++ b/luakmcbook.dtx
@@ -28,7 +28,6 @@
 \usepackage{fancyvrb}
 \newcommand{\VerbBar}{|}
 \newcommand{\VERB}{\Verb[commandchars=\\\{\}]}
-\DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\}}
 % Add ',fontsize=\small' for more characters per line
 \newenvironment{Shaded}{}{}
 \newcommand{\AlertTok}[1]{\textcolor[rgb]{1.00,0.00,0.00}{\textbf{#1}}}
@@ -63,6 +62,10 @@
 \newcommand{\VerbatimStringTok}[1]{\textcolor[rgb]{0.25,0.44,0.63}{#1}}
 \newcommand{\WarningTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{#1}}}}
 \usepackage{graphicx,grffile}
+
+\usepackage{fvextra}
+\DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\}, breaklines, breaknonspaceingroup, breakanywhere}
+\let\NormalTok\texttt
 
 % === ここまで Pandoc のテンプレからもってきたやつ
 


### PR DESCRIPTION
before
[![Image from Gyazo](https://i.gyazo.com/025611f452f4daf2691b9c53a6d6dd86.png)](https://gyazo.com/025611f452f4daf2691b9c53a6d6dd86)
はみ出る。

after
[![Image from Gyazo](https://i.gyazo.com/79f03ecf9a01955cd466ae33c31d8039.png)](https://gyazo.com/79f03ecf9a01955cd466ae33c31d8039)
はみ出ない。

意味はわかってないけど、
https://tex.stackexchange.com/questions/602817/verbatim-breakanywhere-doesnt-have-any-effect-with-a-markdown-using-fvextra-p
に従うとうまいこといった気がする。
