### PR TITLE
最近のKMCを後ろにする

### DIFF
--- a/bushi.tex
+++ b/bushi.tex
@@ -33,6 +33,14 @@
 % 目次生成
 \tableofcontents
 
+
+\part{部員のコラム}
+\include{test}
+
+\include{atogaki}
+
+%\include{kousei}
+
 \part{最近のKMC}
 \chapter{最近のKMC --- 役職者より}
 恒例の「最近のKMC」コーナーです。
@@ -60,12 +68,6 @@ KMCでは、新入生プロジェクト以外にも様々なプロジェクト�
 %\include*{recent-kmc/chalk}
 %\include*{recent-kmc/heavylove}
 
-\part{部員のコラム}
-\include{test}
-
-\include{atogaki}
-
-%\include{kousei}
 
 \makeatletter
 %% 奥付のリンクは脚注をつけない（\hrefをオリジナルの挙動に戻す）


### PR DESCRIPTION
「エッセンシャルKMC」から最近のKMC枠は部員のコラムの後ろに来ています